### PR TITLE
Allows using lowercase drive letters

### DIFF
--- a/FreeMove/Form1.cs
+++ b/FreeMove/Form1.cs
@@ -82,7 +82,7 @@ namespace FreeMove
                 errors += "ERROR, invalid path name\n\n";
                 passing = false;
             }
-            string pattern = @"^[A-Z]:\\{1,2}";
+            string pattern = @"^[A-Za-z]:\\{1,2}";
             if (!Regex.IsMatch(source, pattern) || !Regex.IsMatch(destination, pattern))
             {
                 errors += "ERROR, invalid path format\n\n";


### PR DESCRIPTION
When trying to use paths with lowercase volume letters (like `c:\foo`), an error dialog _ERROR, invalid path format_ is displayed, even though the paths are valid.